### PR TITLE
Add close command for threads/posts

### DIFF
--- a/intbot/core/bot/main.py
+++ b/intbot/core/bot/main.py
@@ -65,7 +65,7 @@ async def close(ctx):
         await ctx.message.delete()
 
         # Send notification to the thread
-        await channel.send(f"# This was marked as done by {author.mention}")
+        await channel.send(f"# This was marked as done by {author.mention}", suppress_embeds=True)
 
         # We need to archive after adding tags in case it was a forum.
         await channel.edit(archived=True)

--- a/intbot/core/bot/main.py
+++ b/intbot/core/bot/main.py
@@ -69,6 +69,13 @@ async def close(ctx):
 
         # We need to archive after adding tags in case it was a forum.
         await channel.edit(archived=True)
+    else:
+        # Remove command message
+        await ctx.message.delete()
+
+        await channel.send("The !close command is intended to be used inside a thread/post",
+                           suppress_embeds=True,
+                           delete_after=5)
 
 
 

--- a/intbot/core/bot/main.py
+++ b/intbot/core/bot/main.py
@@ -64,12 +64,11 @@ async def close(ctx):
         # Remove command message
         await ctx.message.delete()
 
-        # We need to archive after adding tags in case it was a forum.
-        # Otherwise we only archive the thread
-        await channel.edit(archived=True)
-
         # Send notification to the thread
         await channel.send(f"# This was marked as done by {author.mention}")
+        
+        # We need to archive after adding tags in case it was a forum.
+        await channel.edit(archived=True)
 
 
 

--- a/intbot/core/bot/main.py
+++ b/intbot/core/bot/main.py
@@ -38,6 +38,40 @@ async def wiki(ctx):
         suppress_embeds=True,
     )
 
+@bot.command()
+async def close(ctx):
+    channel = ctx.channel
+    parent = channel.parent
+    author = ctx.message.author
+
+    # Check if it's a public or private post (thread)
+    if channel.type in (discord.ChannelType.public_thread, discord.ChannelType.private_thread):
+
+        # Check if the post (thread) was sent in a forum,
+        # so we can add a tag
+        if parent.type == discord.ChannelType.forum:
+
+            # Get tag from forum
+            tag = None
+            for _tag in parent.available_tags:
+                if _tag.name.lower() == "done":
+                    tag = _tag
+                    break
+
+            if tag is not None:
+                await channel.add_tags(tag)
+
+        # Remove command message
+        await ctx.message.delete()
+
+        # We need to archive after adding tags in case it was a forum.
+        # Otherwise we only archive the thread
+        await channel.edit(archived=True)
+
+        # Send notification to the thread
+        await channel.send(f"# This was marked as done by {author.mention}")
+
+
 
 @bot.command()
 async def version(ctx):

--- a/intbot/core/bot/main.py
+++ b/intbot/core/bot/main.py
@@ -66,7 +66,7 @@ async def close(ctx):
 
         # Send notification to the thread
         await channel.send(f"# This was marked as done by {author.mention}")
-        
+
         # We need to archive after adding tags in case it was a forum.
         await channel.edit(archived=True)
 

--- a/intbot/tests/test_bot/test_main.py
+++ b/intbot/tests/test_bot/test_main.py
@@ -102,7 +102,7 @@ async def test_wiki_command():
     )
 
 @pytest.mark.asyncio
-async def test_close_command():
+async def test_close_command_working():
     # Mock context
     ctx = AsyncMock()
     ctx.channel = AsyncMock()
@@ -116,6 +116,23 @@ async def test_close_command():
     ctx.channel.send.assert_called_once_with(
         f"# This was marked as done by {ctx.message.author.mention}",
         suppress_embeds=True,
+    )
+
+@pytest.mark.asyncio
+async def test_close_command_notworking():
+    # Mock context
+    ctx = AsyncMock()
+    ctx.channel = AsyncMock()
+    ctx.message.author = AsyncMock()
+
+    # Call the command
+    await close(ctx)
+
+    # Assert that the command sent the expected message
+    ctx.channel.send.assert_called_once_with(
+        "The !close command is intended to be used inside a thread/post",
+        suppress_embeds=True,
+        delete_after=5
     )
 
 

--- a/intbot/tests/test_bot/test_main.py
+++ b/intbot/tests/test_bot/test_main.py
@@ -105,17 +105,16 @@ async def test_wiki_command():
 async def test_close_command():
     # Mock context
     ctx = AsyncMock()
-    ctx.channel = discord.Thread()
-    ctx.channel.parent = discord.ForumChannel()
-    ctx.author = discord.Member()
-    ctx.author.mention = "TestUser"
+    ctx.channel = AsyncMock()
+    ctx.message.author = AsyncMock()
+    ctx.channel.type = discord.ChannelType.public_thread
 
     # Call the command
     await close(ctx)
 
     # Assert that the command sent the expected message
-    ctx.send.assert_called_once_with(
-        "# This was marked as done by {ctx.author.mention}",
+    ctx.channel.send.assert_called_once_with(
+        f"# This was marked as done by {ctx.message.author.mention}",
         suppress_embeds=True,
     )
 

--- a/intbot/tests/test_bot/test_main.py
+++ b/intbot/tests/test_bot/test_main.py
@@ -1,6 +1,7 @@
 from unittest import mock
 from unittest.mock import AsyncMock, patch
 import contextlib
+import discord
 
 from django.db import connections
 

--- a/intbot/tests/test_bot/test_main.py
+++ b/intbot/tests/test_bot/test_main.py
@@ -6,7 +6,7 @@ from django.db import connections
 
 import pytest
 from asgiref.sync import sync_to_async
-from core.bot.main import ping, poll_database, qlen, source, version, wiki
+from core.bot.main import ping, poll_database, qlen, source, version, wiki, close
 from core.models import DiscordMessage
 from django.utils import timezone
 
@@ -97,6 +97,24 @@ async def test_wiki_command():
     ctx.send.assert_called_once_with(
         "Please add it to the wiki: "
         "[ep2025-wiki.europython.eu](https://ep2025-wiki.europython.eu)",
+        suppress_embeds=True,
+    )
+
+@pytest.mark.asyncio
+async def test_close_command():
+    # Mock context
+    ctx = AsyncMock()
+    ctx.channel = discord.Thread()
+    ctx.channel.parent = discord.ForumChannel()
+    ctx.author = discord.Member()
+    ctx.author.mention = "TestUser"
+
+    # Call the command
+    await close(ctx)
+
+    # Assert that the command sent the expected message
+    ctx.send.assert_called_once_with(
+        "# This was marked as done by {ctx.author.mention}",
         suppress_embeds=True,
     )
 


### PR DESCRIPTION
The command will close the thread (if on a text channel), and archive the post (if on a forum channel).

When in a forum channel, the command will look for a tag from that specific forum called 'done' (each tag will have different IDs depending on the forum) and apply to the post if found.

The bot will send a message notifying who closed it.